### PR TITLE
Add GetMachines method and function

### DIFF
--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -43,6 +43,11 @@ type Netrc struct {
 	updateLock sync.Mutex
 }
 
+// GetMachines returns the list of Machines stored in the netrc file.
+func (n *Netrc) GetMachines() []*Machine {
+	return n.machines
+}
+
 // FindMachine returns the Machine in n named by name. If a machine named by
 // name exists, it is returned. If no Machine with name name is found and there
 // is a ``default'' machine, the ``default'' machine is returned. Otherwise, nil
@@ -494,6 +499,16 @@ func ParseFile(filename string) (*Netrc, error) {
 // If there is a parsing error, an Error is returned.
 func Parse(r io.Reader) (*Netrc, error) {
 	return parse(r, 1)
+}
+
+// GetMachiens parses the netrc file identified by filename and returns the
+// list of Machines.
+func GetMachines(filename string) (machines []*Machine, err error) {
+	n, err := ParseFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return n.GetMachines(), nil
 }
 
 // FindMachine parses the netrc file identified by filename and returns the

--- a/netrc/netrc_test.go
+++ b/netrc/netrc_test.go
@@ -130,6 +130,18 @@ func TestParseFile(t *testing.T) {
 	}
 }
 
+func TestGetMachines(t *testing.T) {
+	machines, err := GetMachines("examples/good.netrc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, m := range machines {
+		if !eqMachine(m, expectedMachines[i]) {
+			t.Errorf("bad machine; expected %v, got %v\n", expectedMachines[1], m)
+		}
+	}
+}
+
 func TestFindMachine(t *testing.T) {
 	m, err := FindMachine("examples/good.netrc", "ray")
 	if err != nil {
@@ -151,6 +163,19 @@ func TestFindMachine(t *testing.T) {
 	}
 	if !m.IsDefault() {
 		t.Errorf("expected m.IsDefault() to be true")
+	}
+}
+
+func TestNetrcGetMachines(t *testing.T) {
+	n, err := ParseFile("examples/good.netrc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	machines := n.GetMachines()
+	for i, m := range machines {
+		if !eqMachine(m, expectedMachines[i]) {
+			t.Errorf("bad machine; expected %v, got %v\n", expectedMachines[1], m)
+		}
 	}
 }
 


### PR DESCRIPTION
Add method GetMachines to Netrc struct, and add stand alone function GetMachines.
The function and method returns the list of all Machines stored in the netrc file.