### PR TITLE
Export Machines member of Netrc

### DIFF
--- a/netrc/netrc.go
+++ b/netrc/netrc.go
@@ -38,7 +38,7 @@ var keywords = map[string]tkType{
 
 type Netrc struct {
 	tokens     []*token
-	machines   []*Machine
+	Machines   []*Machine
 	macros     Macros
 	updateLock sync.Mutex
 }
@@ -50,7 +50,7 @@ type Netrc struct {
 func (n *Netrc) FindMachine(name string) (m *Machine) {
 	// TODO(bgentry): not safe for concurrency
 	var def *Machine
-	for _, m = range n.machines {
+	for _, m = range n.Machines {
 		if m.Name == name {
 			return m
 		}
@@ -126,13 +126,13 @@ func (n *Netrc) NewMachine(name, login, password, account string) *Machine {
 		},
 	}
 	n.insertMachineTokensBeforeDefault(m)
-	for i := range n.machines {
-		if n.machines[i].IsDefault() {
-			n.machines = append(append(n.machines[:i], m), n.machines[i:]...)
+	for i := range n.Machines {
+		if n.Machines[i].IsDefault() {
+			n.Machines = append(append(n.Machines[:i], m), n.Machines[i:]...)
 			return m
 		}
 	}
-	n.machines = append(n.machines, m)
+	n.Machines = append(n.Machines, m)
 	return m
 }
 
@@ -163,15 +163,15 @@ func (n *Netrc) RemoveMachine(name string) {
 	n.updateLock.Lock()
 	defer n.updateLock.Unlock()
 
-	for i := range n.machines {
-		if n.machines[i] != nil && n.machines[i].Name == name {
-			m := n.machines[i]
+	for i := range n.Machines {
+		if n.Machines[i] != nil && n.Machines[i].Name == name {
+			m := n.Machines[i]
 			for _, t := range []*token{
 				m.nametoken, m.logintoken, m.passtoken, m.accounttoken,
 			} {
 				n.removeToken(t)
 			}
-			n.machines = append(n.machines[:i], n.machines[i+1:]...)
+			n.Machines = append(n.Machines[:i], n.Machines[i+1:]...)
 			return
 		}
 	}
@@ -373,7 +373,7 @@ func parse(r io.Reader, pos int) (*Netrc, error) {
 		return nil, err
 	}
 
-	nrc := Netrc{machines: make([]*Machine, 0, 20), macros: make(Macros, 10)}
+	nrc := Netrc{Machines: make([]*Machine, 0, 20), macros: make(Macros, 10)}
 
 	defaultSeen := false
 	var currentMacro *token
@@ -415,7 +415,7 @@ func parse(r io.Reader, pos int) (*Netrc, error) {
 				return nil, &Error{pos, "multiple default token"}
 			}
 			if m != nil {
-				nrc.machines, m = append(nrc.machines, m), nil
+				nrc.Machines, m = append(nrc.Machines, m), nil
 			}
 			m = new(Machine)
 			m.Name = ""
@@ -425,7 +425,7 @@ func parse(r io.Reader, pos int) (*Netrc, error) {
 				return nil, &Error{pos, errBadDefaultOrder}
 			}
 			if m != nil {
-				nrc.machines, m = append(nrc.machines, m), nil
+				nrc.Machines, m = append(nrc.Machines, m), nil
 			}
 			m = new(Machine)
 			if t.rawvalue, m.Name, pos, err = scanValue(scanner, pos); err != nil {
@@ -470,7 +470,7 @@ func parse(r io.Reader, pos int) (*Netrc, error) {
 	}
 
 	if m != nil {
-		nrc.machines, m = append(nrc.machines, m), nil
+		nrc.Machines, m = append(nrc.Machines, m), nil
 	}
 	return &nrc, nil
 }

--- a/netrc/netrc_test.go
+++ b/netrc/netrc_test.go
@@ -33,12 +33,12 @@ func eqMachine(a *Machine, b *Machine) bool {
 }
 
 func testExpected(n *Netrc, t *testing.T) {
-	if len(expectedMachines) != len(n.machines) {
-		t.Errorf("expected %d machines, got %d", len(expectedMachines), len(n.machines))
+	if len(expectedMachines) != len(n.Machines) {
+		t.Errorf("expected %d machines, got %d", len(expectedMachines), len(n.Machines))
 	} else {
 		for i, e := range expectedMachines {
-			if !eqMachine(e, n.machines[i]) {
-				t.Errorf("bad machine; expected %v, got %v\n", e, n.machines[i])
+			if !eqMachine(e, n.Machines[i]) {
+				t.Errorf("bad machine; expected %v, got %v\n", e, n.Machines[i])
 			}
 		}
 	}
@@ -269,7 +269,7 @@ func TestNewMachine(t *testing.T) {
 
 func testNewMachine(t *testing.T, n *Netrc) {
 	for _, test := range newMachineTests {
-		mcount := len(n.machines)
+		mcount := len(n.Machines)
 		// sanity check
 		bodyb, _ := n.MarshalText()
 		body := string(bodyb)
@@ -290,8 +290,8 @@ func testNewMachine(t *testing.T, n *Netrc) {
 			t.Fatalf("NewMachine() returned nil")
 		}
 
-		if len(n.machines) != mcount+1 {
-			t.Errorf("n.machines count expected %d, got %d", mcount+1, len(n.machines))
+		if len(n.Machines) != mcount+1 {
+			t.Errorf("n.Machines count expected %d, got %d", mcount+1, len(n.Machines))
 		}
 		// check values
 		if m.Name != test.name {
@@ -347,7 +347,7 @@ func TestNewMachineGoesBeforeDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 	m := n.NewMachine("mymachine", "mylogin", "mypassword", "myaccount")
-	if m2 := n.machines[len(n.machines)-2]; m2 != m {
+	if m2 := n.Machines[len(n.Machines)-2]; m2 != m {
 		t.Errorf("expected machine %v, got %v", m, m2)
 	}
 }
@@ -361,7 +361,7 @@ func TestRemoveMachine(t *testing.T) {
 	tests := []string{"mail.google.com", "weirdlogin"}
 
 	for _, name := range tests {
-		mcount := len(n.machines)
+		mcount := len(n.Machines)
 		// sanity check
 		m := n.FindMachine(name)
 		if m == nil {
@@ -372,8 +372,8 @@ func TestRemoveMachine(t *testing.T) {
 		}
 		n.RemoveMachine(name)
 
-		if len(n.machines) != mcount-1 {
-			t.Errorf("n.machines count expected %d, got %d", mcount-1, len(n.machines))
+		if len(n.Machines) != mcount-1 {
+			t.Errorf("n.Machines count expected %d, got %d", mcount-1, len(n.Machines))
 		}
 
 		// make sure Machine is no longer returned by FindMachine()


### PR DESCRIPTION
It is useful to be able to examine all the machines in a .netrc file. This
was previously possible. I use it for an update of github.com/naaman/netrc.